### PR TITLE
Update FindCommandParser to support "/all" parameter

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -186,7 +186,7 @@ StaffSync is a **desktop app for managing potential hires and employees, optimiz
   
   >Finds the employee/potential hire whose names contain any of the given keywords.
   >
-  >Format: `find (/e or /ph) KEYWORD [MORE_KEYWORDS]`
+  >Format: `find (/all or /e or /ph) KEYWORD [MORE_KEYWORDS]`
   >
   >* The search is case-insensitive. e.g `hans` will match `Hans`
   >* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
@@ -196,6 +196,7 @@ StaffSync is a **desktop app for managing potential hires and employees, optimiz
   >  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
   >
   >Examples:
+  >* `find /all John` returns people `john` and `John Doe`
   >* `find /e John` returns employees `john` and `John Doe`
   >* `find /ph alex david` returns potential hires `Alex Yeoh`, `David Li`<br>
   >  ![result for 'find alex david'](images/findAlexDavidResult.png)
@@ -215,17 +216,17 @@ StaffSync is a **desktop app for managing potential hires and employees, optimiz
 
 # Commands Summary
 
-Action     | Format                                                            | Examples
------------|-------------------------------------------------------------------|--------------------------------------------------------------------------------------------------
-**Help**   | `?` or `help` |
-**Clear**  | `clear` | 
-**Delete** | `delete e INDEX` <br> `delete ph INDEX` | `delete e 3`<br> `delete ph 1`
-**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​` | `edit 2 n/James Lee e/jameslee@example.com`
+Action     | Format                                                                                        | Examples
+-----------|-----------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------
+**Help**   | `?` or `help`                                                                                 |
+**Clear**  | `clear`                                                                                       | 
+**Delete** | `delete e INDEX` <br> `delete ph INDEX`                                                       | `delete e 3`<br> `delete ph 1`
+**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`                        | `edit 2 n/James Lee e/jameslee@example.com`
 **Employee**| `employee n/NAME p/PHONE_NUMBER a/ADDRESS e/EMAIL d/DEPARTMENT r/ROLE ced/CONTRACT_END_DATE​` | `employee n/Jun Kang p/81234567 a/21 Lower Kent Ridge Rd e/pohjunkang@gmail.com d/Department of communications and informatics r/Head of communications and Informatics ced/01-01-2021`
-**Exit**   | `exit` | 
-**Find**   | `find e [KEYWORDS]` <br> `find ph [KEYWORDS]` | `find e Jake` <br> `find ph Jake`
-**List**   | `list` | 
-**Potential Hire**| `potential n/NAME p/PHONE_NUMBER a/ADDRESS e/EMAIL d/DEPARTMENT r/ROLE​` | `potential n/Jun Kang p/81234567 a/21 Lower Kent Ridge Rd e/pohjunkang@gmail.com d/Department of communications and informatics r/Head of communications and Informatics`
+**Exit**   | `exit`                                                                                        | 
+**Find**   | `find /all [KEYWORDS]` <br> `find /e [KEYWORDS]` <br> `find /ph [KEYWORDS]`                   | `find /all Jake` <br> `find /e Jake` <br> `find /ph Jake`
+**List**   | `list`                                                                                        | 
+**Potential Hire**| `potential n/NAME p/PHONE_NUMBER a/ADDRESS e/EMAIL d/DEPARTMENT r/ROLE​`                      | `potential n/Jun Kang p/81234567 a/21 Lower Kent Ridge Rd e/pohjunkang@gmail.com d/Department of communications and informatics r/Head of communications and Informatics`
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -15,11 +15,13 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
+    public static final String ARGUMENT_WORD = "/all";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all employees and potential hires whose names "
             + "contain any of the specified keywords (case-insensitive) and displays them as a list with "
             + "index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Parameters: (/all or /e or /ph) KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " " + ARGUMENT_WORD + " alice bob charlie";
 
     private final NameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -36,8 +36,12 @@ public class FindCommandParser implements Parser<FindCommand> {
         } else if (typeOfPerson.equals(FindPotentialCommand.ARGUMENT_WORD)) {
             return new FindPotentialCommand(new NameContainsKeywordsPredicate(Arrays.asList(
                     Arrays.copyOfRange(nameKeywords, 1, nameKeywords.length))));
+        } else if (typeOfPerson.equals(FindCommand.ARGUMENT_WORD)) {
+            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(
+                    Arrays.copyOfRange(nameKeywords, 1, nameKeywords.length))));
         } else {
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -75,8 +75,10 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
+
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + FindCommand.ARGUMENT_WORD + " "
+                        + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
 
         FindEmployeeCommand employeeCommand = (FindEmployeeCommand) parser.parseCommand(

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -21,6 +21,11 @@ public class FindCommandParserTest {
     }
 
     @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "/a john", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -25,10 +25,10 @@ public class FindCommandParserTest {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, "/all Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, "/all \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
 }


### PR DESCRIPTION
## Describe your changes
- Modified FindCommandParser.parse() to accept "/all" as a parameter.
- If parameter is not (/all or /e or /ph), ParseException is thrown
- Update UserGuide

## Issue ticket number and link
closes #74 

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.
