### PR TITLE
Add test for FindCommandParser when parsing empty keywords

### DIFF
--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -36,4 +36,13 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, "all \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
+    @Test
+    public void parse_empty_keywords() {
+        assertParseFailure(parser, "all", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "eph", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+
+        assertParseFailure(parser, "e", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
 }


### PR DESCRIPTION
## Describe your changes
- Add empty keywords test for FindCommandParser to parse
- For inputs: "find all", "find ph", "find all"
- Improve code coverage

## Issue ticket number and link
closes #101 

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.
