### PR TITLE
Modify delete to support extra spaces bet params

### DIFF
--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -14,6 +14,17 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
 
+    private boolean deleteParserCheck(String args, String commandType) throws ParseException {
+        if (args.startsWith(commandType)) {
+            if (args.startsWith(commandType + " ")) {
+                return true;
+            }
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
+        return false;
+    }
+
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
@@ -21,21 +32,15 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         args = args.trim();
+        Index index;
         try {
-            String[] argsArray = args.split(" ");
-            if (argsArray.length > 2) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-            }
-
-            String type = argsArray[0];
-            Index index = ParserUtil.parseIndex(argsArray[1]);
-
-            if (type.equals(DeleteEmployeeCommand.COMMAND_TYPE)) {
+            if (deleteParserCheck(args, DeleteEmployeeCommand.COMMAND_TYPE)) {
+                index = ParserUtil.parseIndex(args.substring(DeleteEmployeeCommand.COMMAND_TYPE.length()).trim());
                 return new DeleteEmployeeCommand(index);
-            } else if (type.equals(DeletePotentialCommand.COMMAND_TYPE)) {
+            } else if (deleteParserCheck(args, DeletePotentialCommand.COMMAND_TYPE)) {
+                index = ParserUtil.parseIndex(args.substring(DeletePotentialCommand.COMMAND_TYPE.length()).trim());
                 return new DeletePotentialCommand(index);
             }
-
             throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_TYPE);
         } catch (IndexOutOfBoundsException e) {
             throw new ParseException(

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeletePotentialCommand;
+import seedu.address.logic.commands.DeleteEmployeeCommand;
 import seedu.address.logic.commands.DemoteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
@@ -63,8 +63,10 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_delete() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " ph " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeletePotentialCommand(INDEX_FIRST_PERSON), command);
+                DeleteCommand.COMMAND_WORD + " "
+                        + DeleteEmployeeCommand.COMMAND_TYPE + " "
+                        + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteEmployeeCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -42,13 +42,12 @@ public class DeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "a a", String.format(ParserUtil.MESSAGE_INVALID_INDEX));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_PERSON_DISPLAYED_TYPE));
+        assertParseFailure(parser, "a a", String.format(MESSAGE_INVALID_PERSON_DISPLAYED_TYPE));
         assertParseFailure(parser, "a 1", String.format(MESSAGE_INVALID_PERSON_DISPLAYED_TYPE));
         assertParseFailure(parser, "e", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "e e", String.format(ParserUtil.MESSAGE_INVALID_INDEX));
-        assertParseFailure(parser, "e 1 e", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, "e  1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "e 1 e", String.format(ParserUtil.MESSAGE_INVALID_INDEX));
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_PERSON_DISPLAYED_TYPE));
     }
 }


### PR DESCRIPTION
## Describe your changes
Fixes the issue where spaces between parameters for delete would not work like `delete         ph      1`

## Issue ticket number and link
Closes #120 

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.
