### PR TITLE
Update FindCommandParser to throw an error message when there are emp…

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -92,4 +92,40 @@ public class ArgumentMultimap {
                 && getValue(PREFIX_EMAIL).isEmpty() && getValue(PREFIX_DEPARTMENT).isEmpty()
                 && getValue(PREFIX_ROLE).isEmpty();
     }
+
+    /**
+     * Checks if the {@code argumentMultimap} contains any empty string mapped to any of the prefixes
+     * required for FindCommand.
+     * Prefix required for FindCommand includes "n/", "p/", "e/", "d/", "/r".
+     *
+     * @return True if at least one empty string is mapped to a prefix.
+     */
+    public boolean hasEmptyCommandPrefix() {
+        List<String> listOfNameKeywords = getAllValues(PREFIX_NAME);
+        if (!listOfNameKeywords.isEmpty()) {
+            String firstNameKeyword = listOfNameKeywords.get(0);
+            return firstNameKeyword.trim().isEmpty();
+        }
+        List<String> listOfPhoneKeywords = getAllValues(PREFIX_PHONE);
+        if (!listOfPhoneKeywords.isEmpty()) {
+            String firstPhoneKeyword = listOfPhoneKeywords.get(0);
+            return firstPhoneKeyword.trim().isEmpty();
+        }
+        List<String> listOfEmailKeywords = getAllValues(PREFIX_EMAIL);
+        if (!listOfEmailKeywords.isEmpty()) {
+            String firstEmailKeyword = listOfEmailKeywords.get(0);
+            return firstEmailKeyword.trim().isEmpty();
+        }
+        List<String> listOfDepartmentKeywords = getAllValues(PREFIX_DEPARTMENT);
+        if (!listOfDepartmentKeywords.isEmpty()) {
+            String firstDepartmentKeyword = listOfDepartmentKeywords.get(0);
+            return firstDepartmentKeyword.trim().isEmpty();
+        }
+        List<String> listOfRoleKeywords = getAllValues(PREFIX_ROLE);
+        if (!listOfRoleKeywords.isEmpty()) {
+            String firstRoleKeyword = listOfRoleKeywords.get(0);
+            return firstRoleKeyword.trim().isEmpty();
+        }
+        return false;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -19,6 +19,8 @@ import seedu.address.model.person.PredicateContainer;
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+    public static final String MESSAGE_NO_PREFIX = "Missing prefix! At least one prefix is required!";
+    public static final String MESSAGE_NO_KEYWORD = "Missing keyword after prefix! It cannot be empty!";
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
@@ -39,8 +41,12 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
         if (argMultimap.hasNoFindCommandPrefix()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, FindCommandParser.MESSAGE_NO_PREFIX));
+        }
+        if (argMultimap.hasEmptyCommandPrefix()) {
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, FindCommandParser.MESSAGE_NO_KEYWORD));
         }
 
         PredicateContainer predicateContainer = PredicateContainer.extractFromArgumentMultimap(argMultimap);

--- a/src/main/java/seedu/address/model/person/PredicateContainer.java
+++ b/src/main/java/seedu/address/model/person/PredicateContainer.java
@@ -13,6 +13,7 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Contains all predicates for FindCommand
@@ -192,7 +193,7 @@ public class PredicateContainer {
      * @param argMultimap ArgumentMultimap to extract from
      * @return {@code PredicateContainer} with {@code Predicate} after parsing added.
      */
-    public static PredicateContainer extractFromArgumentMultimap(ArgumentMultimap argMultimap) {
+    public static PredicateContainer extractFromArgumentMultimap(ArgumentMultimap argMultimap) throws ParseException {
         PredicateContainer predicateContainer = new PredicateContainer();
         predicateContainer.addNameContainsKeywordsPredicateusingArgMultimap(argMultimap);
         predicateContainer.addPhoneContainsKeywordsPredicateusingArgMultimap(argMultimap);

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,12 @@
 package seedu.address.logic.parser;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DEPARTMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ROLE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.FindCommandParser.MESSAGE_NO_KEYWORD;
@@ -122,6 +128,16 @@ public class FindCommandParserTest {
         assertParseFailure(parser, "ph p/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
 
         assertParseFailure(parser, "e e/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
+
+        assertParseFailure(parser, "all d/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
+
+        assertParseFailure(parser, "ph e/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
+
+        String args = "all n/John";
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                        PREFIX_DEPARTMENT, PREFIX_ROLE);
+        assertFalse(argMultimap.hasEmptyCommandPrefix());
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -3,6 +3,8 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.FindCommandParser.MESSAGE_NO_KEYWORD;
+import static seedu.address.logic.parser.FindCommandParser.MESSAGE_NO_PREFIX;
 
 import java.util.Arrays;
 
@@ -105,12 +107,21 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_empty_keywords() {
-        assertParseFailure(parser, "all", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    public void parse_no_prefix() {
+        assertParseFailure(parser, "all", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_PREFIX));
 
-        assertParseFailure(parser, "ph", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "ph", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_PREFIX));
 
-        assertParseFailure(parser, "e", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "e", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_PREFIX));
+    }
+
+    @Test
+    public void parse_no_keywords() {
+        assertParseFailure(parser, "all n/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
+
+        assertParseFailure(parser, "ph p/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
+
+        assertParseFailure(parser, "e e/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -131,9 +131,9 @@ public class FindCommandParserTest {
 
         assertParseFailure(parser, "all d/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
 
-        assertParseFailure(parser, "ph e/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
+        assertParseFailure(parser, "ph r/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_NO_KEYWORD));
 
-        String args = "all n/John";
+        String args = "all n/John p/98765432 e/john@example.com d/IT r/SWE";
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_DEPARTMENT, PREFIX_ROLE);


### PR DESCRIPTION
## Describe your changes
- Update FindCommandParser to throw an error when there are empty keywords after prefix

## Issue ticket number and link
closes #276 
closes #278  
closes #280 

## Checklist before requesting a review
- [X] I have performed a self-review of my code.
- [X] If it is a core feature, I have added thorough tests.
